### PR TITLE
Allow package to be installed on project `frameworktarget=v4.0`

### DIFF
--- a/src/AutofacSerilogIntegration/AutofacSerilogIntegration.csproj
+++ b/src/AutofacSerilogIntegration/AutofacSerilogIntegration.csproj
@@ -35,11 +35,9 @@
     </Reference>
     <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.1.5.7\lib\net40\Serilog.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.FullNetFx">
       <HintPath>..\..\packages\Serilog.1.5.7\lib\net40\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/AutofacSerilogIntegration/AutofacSerilogIntegration.csproj
+++ b/src/AutofacSerilogIntegration/AutofacSerilogIntegration.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutofacSerilogIntegration</RootNamespace>
     <AssemblyName>AutofacSerilogIntegration</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -34,10 +34,12 @@
       <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.1.5.7\lib\net40\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.1.5.7\lib\net40\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/AutofacSerilogIntegration/ContextualLoggingModule.cs
+++ b/src/AutofacSerilogIntegration/ContextualLoggingModule.cs
@@ -89,7 +89,7 @@ namespace AutofacSerilogIntegration
                     var log = args.Context.Resolve<ILogger>().ForContext(registration.Activator.LimitType);
                     foreach (var targetProperty in targetProperties)
                     {
-                        targetProperty.SetValue(args.Instance, log);
+                        targetProperty.SetValue(args.Instance, log, null);
                     }
                 };
             }

--- a/src/AutofacSerilogIntegration/packages.config
+++ b/src/AutofacSerilogIntegration/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="Serilog" version="1.5.7" targetFramework="net45" />
+  <package id="Serilog" version="1.5.7" targetFramework="net4" />
 </packages>


### PR DESCRIPTION
Change the target framework for the project and `Serilog` package to v4.0 to allow package to be installed on projects v4.0 