### PR TITLE
Add support for injecting private properties

### DIFF
--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -37,6 +37,18 @@ namespace Example
         }
     }
 
+    class AcceptsLogViaPrivateProperty : IExample
+    {
+        private static ILogger Log { get; set; }
+
+        public void Show()
+        {
+            Log.Information("Hello, via private property injected logger!");
+        }
+    }
+
+
+
     class Program
     {
         static void Main()
@@ -50,9 +62,10 @@ namespace Example
             try
             {
                 var builder = new ContainerBuilder();
-                builder.RegisterLogger(autowireProperties: true);
+                builder.RegisterLogger(autowireProperties: true, autowirePrivateProperties: true);
                 builder.RegisterType<AcceptsLogViaCtor>().As<IExample>();
                 builder.RegisterType<AcceptsLogViaProperty>().As<IExample>();
+                builder.RegisterType<AcceptsLogViaPrivateProperty>().As<IExample>();
 
                 using (var container = builder.Build())
                 {

--- a/src/AutofacSerilogIntegration/SerilogContainerBuilderExtensions.cs
+++ b/src/AutofacSerilogIntegration/SerilogContainerBuilderExtensions.cs
@@ -18,11 +18,12 @@ namespace AutofacSerilogIntegration
         /// <param name="logger">The logger. If null, the static <see cref="Log.Logger"/> will be used.</param>
         /// <param name="autowireProperties">If true, properties on reflection-based components of type <see cref="ILogger"/> will
         /// be injected.</param>
+        /// <param name="autowirePrivateProperties">If true, private properties of type <see cref="ILogger"/> will be injected.</param>
         /// <returns>An object supporting method chaining.</returns>
-        public static IModuleRegistrar RegisterLogger(this ContainerBuilder builder, ILogger logger = null, bool autowireProperties = false)
+        public static IModuleRegistrar RegisterLogger(this ContainerBuilder builder, ILogger logger = null, bool autowireProperties = false, bool autowirePrivateProperties = false)
         {
             if (builder == null) throw new ArgumentNullException("builder");
-            return builder.RegisterModule(new ContextualLoggingModule(logger, autowireProperties));
+            return builder.RegisterModule(new ContextualLoggingModule(logger, autowireProperties, autowirePrivateProperties));
         }
     }
 }


### PR DESCRIPTION
By setting the property autowirePrivateProperties=true your private
ILogger properties will be injected with the proper logger. This helps
reducing noise in the public api by keeping the logging facility private.
