### PR TITLE
Adding a simple switch to exclude unnecessary activations

### DIFF
--- a/src/AutofacSerilogIntegration/ContextualLoggingModule.cs
+++ b/src/AutofacSerilogIntegration/ContextualLoggingModule.cs
@@ -107,7 +107,7 @@ namespace AutofacSerilogIntegration
                     {
                         ctors = ra.ConstructorFinder.FindConstructors(ra.LimitType);
                     }
-                    catch (Exception ex) when (ex.GetType().Name == "NoConstructorsFoundException") // Avoid needing to upgrade our Autofac reference to 4.7.0
+                    catch (NoConstructorsFoundException)
                     {
                         ctors = new ConstructorInfo[0];
                     }

--- a/src/AutofacSerilogIntegration/ContextualLoggingModule.cs
+++ b/src/AutofacSerilogIntegration/ContextualLoggingModule.cs
@@ -18,6 +18,7 @@ namespace AutofacSerilogIntegration
         readonly bool _autowireProperties;
         readonly bool _skipRegistration;
         readonly bool _dispose;
+        readonly bool _onlyKnownConsumers;
 
         [Obsolete("Do not use this constructor. This is required by the Autofac assembly scanning")]
         public ContextualLoggingModule()
@@ -26,11 +27,12 @@ namespace AutofacSerilogIntegration
             _skipRegistration = true;
         }
 
-        internal ContextualLoggingModule(ILogger logger = null, bool autowireProperties = false, bool dispose = false)
+        internal ContextualLoggingModule(ILogger logger = null, bool autowireProperties = false, bool dispose = false, bool onlyKnownConsumers = false)
         {
             _logger = logger;
             _autowireProperties = autowireProperties;
             _dispose = dispose;
+            _onlyKnownConsumers = onlyKnownConsumers;
             _skipRegistration = false;
         }
 
@@ -94,8 +96,7 @@ namespace AutofacSerilogIntegration
 
             PropertyInfo[] targetProperties = null;
 
-            var ra = registration.Activator as ReflectionActivator;
-            if (ra != null)
+            if (registration.Activator is ReflectionActivator ra)
             {
                 // As of Autofac v4.7.0 "FindConstructors" will throw "NoConstructorsFoundException" instead of returning an empty array
                 // See: https://github.com/autofac/Autofac/pull/895 & https://github.com/autofac/Autofac/issues/733
@@ -128,6 +129,11 @@ namespace AutofacSerilogIntegration
 
                 // Ignore components known to be without logger dependencies
                 if (!usesLogger)
+                    return;
+            }
+            else
+            {
+                if (_onlyKnownConsumers)
                     return;
             }
 

--- a/src/AutofacSerilogIntegration/ContextualLoggingModule.cs
+++ b/src/AutofacSerilogIntegration/ContextualLoggingModule.cs
@@ -119,8 +119,7 @@ namespace AutofacSerilogIntegration
                     {
                         var logProperties = ra.LimitType
                             .GetRuntimeProperties()
-                            .Where(c => c.CanWrite && c.PropertyType == typeof(ILogger) && c.SetMethod.IsPublic &&
-                                        !c.SetMethod.IsStatic)
+                            .Where(c => c.CanWrite && c.PropertyType == typeof(ILogger) && c.SetMethod.IsPublic && !c.SetMethod.IsStatic)
                             .ToArray();
 
                         if (logProperties.Any())

--- a/src/AutofacSerilogIntegration/SerilogContainerBuilderExtensions.cs
+++ b/src/AutofacSerilogIntegration/SerilogContainerBuilderExtensions.cs
@@ -19,15 +19,15 @@ namespace AutofacSerilogIntegration
         /// <param name="autowireProperties">If true, properties on reflection-based components of type <see cref="ILogger"/> will
         /// be injected.</param>
         /// <param name="dispose"></param>
-        /// <param name="onlyKnownConsumers">
-        /// If true, only the registrations that can be verified to use <see cref="ILogger"/> will be modified to access the logger,
-        /// thus avoiding unnecessary logger calls.
-        ///  </param>
+        /// <param name="alwaysSupplyParameter">
+        /// If true, the parameter containing <see cref="ILogger"/> will be injected even when registration cannot be verified to use it,
+        /// such as <see cref="Autofac.Core.Activators.Delegate.DelegateActivator"/>.
+        /// </param>
         /// <returns>An object supporting method chaining.</returns>
-        public static IModuleRegistrar RegisterLogger(this ContainerBuilder builder, ILogger logger = null, bool autowireProperties = false, bool dispose = false, bool onlyKnownConsumers = false)
+        public static IModuleRegistrar RegisterLogger(this ContainerBuilder builder, ILogger logger = null, bool autowireProperties = false, bool dispose = false, bool alwaysSupplyParameter = false)
         {
             if (builder == null) throw new ArgumentNullException(nameof(builder));
-            return builder.RegisterModule(new ContextualLoggingModule(logger, autowireProperties, dispose, onlyKnownConsumers));
+            return builder.RegisterModule(new ContextualLoggingModule(logger, autowireProperties, dispose, alwaysSupplyParameter));
         }
     }
 }

--- a/src/AutofacSerilogIntegration/SerilogContainerBuilderExtensions.cs
+++ b/src/AutofacSerilogIntegration/SerilogContainerBuilderExtensions.cs
@@ -19,11 +19,15 @@ namespace AutofacSerilogIntegration
         /// <param name="autowireProperties">If true, properties on reflection-based components of type <see cref="ILogger"/> will
         /// be injected.</param>
         /// <param name="dispose"></param>
+        /// <param name="onlyKnownConsumers">
+        /// If true, only the registrations that can be verified to use <see cref="ILogger"/> will be modified to access the logger,
+        /// thus avoiding unnecessary logger calls.
+        ///  </param>
         /// <returns>An object supporting method chaining.</returns>
-        public static IModuleRegistrar RegisterLogger(this ContainerBuilder builder, ILogger logger = null, bool autowireProperties = false, bool dispose = false)
+        public static IModuleRegistrar RegisterLogger(this ContainerBuilder builder, ILogger logger = null, bool autowireProperties = false, bool dispose = false, bool onlyKnownConsumers = false)
         {
-            if (builder == null) throw new ArgumentNullException("builder");
-            return builder.RegisterModule(new ContextualLoggingModule(logger, autowireProperties, dispose));
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            return builder.RegisterModule(new ContextualLoggingModule(logger, autowireProperties, dispose, onlyKnownConsumers));
         }
     }
 }

--- a/test/AutofacSerilogIntegration.Tests/ActivatorTests.cs
+++ b/test/AutofacSerilogIntegration.Tests/ActivatorTests.cs
@@ -16,11 +16,16 @@ namespace AutofacSerilogIntegration.Tests
             _logger.SetReturnsDefault(_logger.Object);
         }
 
-        private void ResolveInstance<TDependency>(Action<ContainerBuilder> configureContainer)
+        private void ResolveInstance<TDependency>(Action<ContainerBuilder> configureContainer, bool? onlyKnownConsumers)
         {
             var containerBuilder = new ContainerBuilder();
+
+            if (onlyKnownConsumers == null)
+                containerBuilder.RegisterLogger(_logger.Object);
+            else
+                containerBuilder.RegisterLogger(_logger.Object, onlyKnownConsumers: onlyKnownConsumers.Value);
+
             containerBuilder.RegisterType<Component<TDependency>>();
-            containerBuilder.RegisterLogger(_logger.Object);
             configureContainer(containerBuilder);
             using (var container = containerBuilder.Build())
             {
@@ -31,34 +36,58 @@ namespace AutofacSerilogIntegration.Tests
         private void VerifyLoggerCreation<TContext>(Func<Times> times)
             => _logger.Verify(logger => logger.ForContext(typeof(TContext)), times);
 
-        [Fact]
-        public void Default_ReflectionActivator_DependencyWithLogger_ShouldCreateLogger()
+        [Theory]
+        [InlineData(null)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ReflectionActivator_DependencyWithLogger_ShouldCreateLogger(bool? onlyKnownConsumers)
         {
-            ResolveInstance<DependencyWithLogger>(containerBuilder => containerBuilder.RegisterType<DependencyWithLogger>());
+            ResolveInstance<DependencyWithLogger>(containerBuilder => containerBuilder.RegisterType<DependencyWithLogger>(), onlyKnownConsumers);
             VerifyLoggerCreation<DependencyWithLogger>(Times.AtLeastOnce);
         }
 
-        [Fact]
-        public void Default_ReflectionActivator_DependencyWithoutLogger_ShouldNotCreateLogger()
+        [Theory]
+        [InlineData(null)]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ReflectionActivator_DependencyWithoutLogger_ShouldNotCreateLogger(bool? onlyKnownConsumers)
         {
-            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.RegisterType<DependencyWithoutLogger>());
+            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.RegisterType<DependencyWithoutLogger>(), onlyKnownConsumers);
+            VerifyLoggerCreation<DependencyWithoutLogger>(Times.Never);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(false)]
+        //legacy behavior
+        public void Default_ProvidedInstanceActivator_DependencyWithoutLogger_CreatesLogger(bool? onlyKnownConsumers)
+        {
+            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.RegisterInstance(new DependencyWithoutLogger()), onlyKnownConsumers);
+            VerifyLoggerCreation<DependencyWithoutLogger>(Times.AtLeastOnce);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(false)]
+        //legacy behavior
+        public void Default_DelegateActivator_DependencyWithoutLogger_CreatesLogger(bool? onlyKnownConsumers)
+        {
+            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.Register(_ => new DependencyWithoutLogger()), onlyKnownConsumers);
+            VerifyLoggerCreation<DependencyWithoutLogger>(Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public void OnlyKnownCustomers_ProvidedInstanceActivator_DependencyWithoutLogger_ShouldNotCreateLogger()
+        {
+            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.RegisterInstance(new DependencyWithoutLogger()), onlyKnownConsumers: true);
             VerifyLoggerCreation<DependencyWithoutLogger>(Times.Never);
         }
 
         [Fact]
-        //legacy behavior
-        public void Default_ProvidedInstanceActivator_DependencyWithoutLogger_CreatesLogger()
+        public void OnlyKnownCustomers_DelegateActivator_DependencyWithoutLogger_ShouldNotCreateLogger()
         {
-            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.RegisterInstance(new DependencyWithoutLogger()));
-            VerifyLoggerCreation<DependencyWithoutLogger>(Times.AtLeastOnce);
-        }
-
-        [Fact]
-        //legacy behavior
-        public void Default_DelegateActivator_DependencyWithoutLogger_CreatesLogger()
-        {
-            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.Register(_ => new DependencyWithoutLogger()));
-            VerifyLoggerCreation<DependencyWithoutLogger>(Times.AtLeastOnce);
+            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.Register(_ => new DependencyWithoutLogger()), onlyKnownConsumers: true);
+            VerifyLoggerCreation<DependencyWithoutLogger>(Times.Never);
         }
 
         private class Component<TDependency>

--- a/test/AutofacSerilogIntegration.Tests/ActivatorTests.cs
+++ b/test/AutofacSerilogIntegration.Tests/ActivatorTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Autofac;
+using Moq;
+using Serilog;
+using Xunit;
+
+namespace AutofacSerilogIntegration.Tests
+{
+    public class ActivatorTests
+    {
+        private readonly Mock<ILogger> _logger;
+
+        public ActivatorTests()
+        {
+            _logger = new Mock<ILogger>();
+            _logger.SetReturnsDefault(_logger.Object);
+        }
+
+        private void ResolveInstance<TDependency>(Action<ContainerBuilder> configureContainer)
+        {
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.RegisterType<Component<TDependency>>();
+            containerBuilder.RegisterLogger(_logger.Object);
+            configureContainer(containerBuilder);
+            using (var container = containerBuilder.Build())
+            {
+                container.Resolve<Component<TDependency>>();
+            }
+        }
+
+        private void VerifyLoggerCreation<TContext>(Func<Times> times)
+            => _logger.Verify(logger => logger.ForContext(typeof(TContext)), times);
+
+        [Fact]
+        public void Default_ReflectionActivator_DependencyWithLogger_ShouldCreateLogger()
+        {
+            ResolveInstance<DependencyWithLogger>(containerBuilder => containerBuilder.RegisterType<DependencyWithLogger>());
+            VerifyLoggerCreation<DependencyWithLogger>(Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public void Default_ReflectionActivator_DependencyWithoutLogger_ShouldNotCreateLogger()
+        {
+            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.RegisterType<DependencyWithoutLogger>());
+            VerifyLoggerCreation<DependencyWithoutLogger>(Times.Never);
+        }
+
+        [Fact]
+        //legacy behavior
+        public void Default_ProvidedInstanceActivator_DependencyWithoutLogger_CreatesLogger()
+        {
+            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.RegisterInstance(new DependencyWithoutLogger()));
+            VerifyLoggerCreation<DependencyWithoutLogger>(Times.AtLeastOnce);
+        }
+
+        [Fact]
+        //legacy behavior
+        public void Default_DelegateActivator_DependencyWithoutLogger_CreatesLogger()
+        {
+            ResolveInstance<DependencyWithoutLogger>(containerBuilder => containerBuilder.Register(_ => new DependencyWithoutLogger()));
+            VerifyLoggerCreation<DependencyWithoutLogger>(Times.AtLeastOnce);
+        }
+
+        private class Component<TDependency>
+        {
+            public Component(TDependency dependency)
+            {
+            }
+        }
+
+        private class DependencyWithLogger
+        {
+            public DependencyWithLogger(ILogger logger)
+            {
+            }
+        }
+
+        private class DependencyWithoutLogger {}
+    }
+}


### PR DESCRIPTION
An option 3 from #34:

> create a switch, something like `RegisterLogger(..., bool onlyForKnownConsumers: false)`, which will enable the behavior above [activation limiting] for implementation cases like ours