### PR TITLE
Dev logger lambda

### DIFF
--- a/src/AutofacSerilogIntegration/SerilogContainerBuilderExtensions.cs
+++ b/src/AutofacSerilogIntegration/SerilogContainerBuilderExtensions.cs
@@ -29,5 +29,25 @@ namespace AutofacSerilogIntegration
             if (builder == null) throw new ArgumentNullException(nameof(builder));
             return builder.RegisterModule(new ContextualLoggingModule(logger, autowireProperties, dispose, alwaysSupplyParameter));
         }
+        
+        /// <summary>
+        /// Register the <see cref="ILogger"/> with the <see cref="ContainerBuilder"/>. Where possible, the logger will
+        /// be resolved using the target type as a tagged property.
+        /// </summary>
+        /// <param name="builder">The container builder.</param>
+        /// <param name="loggerLambda">Function to resolve logger from context. If resolution yeilds null, the static <see cref="Log.Logger"/> will be used. </param>
+        /// <param name="autowireProperties">If true, properties on reflection-based components of type <see cref="ILogger"/> will
+        /// be injected.</param>
+        /// <param name="dispose"></param>
+        /// <param name="alwaysSupplyParameter">
+        /// If true, the parameter containing <see cref="ILogger"/> will be injected even when registration cannot be verified to use it,
+        /// such as <see cref="Autofac.Core.Activators.Delegate.DelegateActivator"/>.
+        /// </param>
+        /// <returns>An object supporting method chaining.</returns>
+        public static IModuleRegistrar RegisterLogger(this ContainerBuilder builder, Func<IComponentContext, ILogger> loggerLambda, bool autowireProperties = false, bool dispose = false, bool alwaysSupplyParameter = false)
+        {
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            return builder.RegisterModule(new ContextualLoggingModule(loggerLambda, autowireProperties, dispose, alwaysSupplyParameter));
+        }
     }
 }


### PR DESCRIPTION
I am writing a net.core worker service project. There is no Startup class there. Updating Log after host has been built does not work as expected as only child scopes are affected. I am configuring serilog in code using custom config file which stores things connection strings for SQL Server sink. The only option I have found is to hide initialization inside lamba. This is a real autofac-style,

Sample usage:

```
using Autofac;
using AutofacSerilogIntegration;
using Microsoft.Extensions.Options;
using Serilog.Core;

public class SerilogConfiguratorFromSettings : IStartable {

    private readonly IOptionsMonitor<MyLoggingSettingsFromConfig> _MyLoggingSettingsFromConfigLive;
    public Logger logger { get; private set; }

    public SerilogConfiguratorFromSettings(IOptionsMonitor<MyLoggingSettingsFromConfig> MyLoggingSettingsFromConfigLive)
        => _MyLoggingSettingsFromConfigLive = MyLoggingSettingsFromConfigLive;

    public void Start()
        => logger = SerilogConfigurator.GetLoggerFromSettings(_MyLoggingSettingsFromConfigLive.CurrentValue);

}

public class LoggingModule : Module {

    protected override void Load(ContainerBuilder builder) {
        builder
            .RegisterType<SerilogConfiguratorFromSettings>()
            .As<IStartable>()
            .SingleInstance() //config is read once
            //.InstancePerLifetimeScope() //this allows to reread config for each new lifetime scope
            ;

        builder.RegisterLogger(
            loggerLambda: c => c.Resolve<SerilogConfiguratorFromSettings>().logger
            , autowireProperties: true);
    }
}

```